### PR TITLE
Run compile before publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
           check-latest: true
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
+      - run: npm run compile
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'


### PR DESCRIPTION
This PR fixes the issue where the currently published npm package is empty due the dist folder not being compiled.