### PR TITLE
chore: only publish `dist/lib` folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "main": "dist/lib/index.js",
   "types": "dist/lib/index.d.ts",
   "files": [
-    "dist/**/*"
+    "dist/lib"
   ],
   "engines": {
     "node": ">=16.0.0"


### PR DESCRIPTION
Avoid shipping the 82KB `tsconfig.build.tsbuildinfo` file.